### PR TITLE
Bump actions/upload-pages-artifact to v4.

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./public
 

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-docker build -t code .

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,0 @@
-docker run -it \
-	-v .:/host \
-	-p 1313:1313 \
-	code


### PR DESCRIPTION
1. Bump actions/upload-pages-artifact to v4.
2. Remove run scripts in favor of Make targets.